### PR TITLE
Fix unexpected promise rejection in test

### DIFF
--- a/src/__tests__/__browser__/index.js
+++ b/src/__tests__/__browser__/index.js
@@ -30,9 +30,9 @@ test('failure status request', t => {
     Promise.resolve({json: () => ({status: 'failure', data: 'failure data'})});
   const rpc = RPC({fetch}).of();
   t.equals(typeof rpc.request, 'function', 'has method');
-  t.ok(rpc.request('test') instanceof Promise, 'has right return type');
-  rpc
-    .request('test')
+  const testRequest = rpc.request('test');
+  t.ok(testRequest instanceof Promise, 'has right return type');
+  testRequest
     .then(() => {
       t.fail(new Error('should reject promise'));
     })


### PR DESCRIPTION
Previously we were kicking off two promises and only catching one of them. The output from the other promise caused unitest to fail due to output after t.end(). This was hidden during upgrade by masking of failures in CI.