### PR TITLE
await next in middleware

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -282,8 +282,10 @@ test('middleware - valid endpoint', async t => {
       body: 'test-args',
     },
   };
+  let executedHandler = false;
   const mockHandlers = {
     test(args, ctx) {
+      executedHandler = true;
       t.equal(args, 'test-args');
       t.equal(ctx, mockCtx);
       return 1;
@@ -307,7 +309,11 @@ test('middleware - valid endpoint', async t => {
     handlers: mockHandlers,
   });
   try {
-    await middleware(mockCtx, () => Promise.resolve());
+    await middleware(mockCtx, () => {
+      t.equal(executedHandler, false, 'awaits next');
+      Promise.resolve();
+    });
+    t.equal(executedHandler, true);
     t.equal(mockCtx.body.data, 1);
     t.equal(mockCtx.body.status, 'success');
   } catch (e) {

--- a/src/server.js
+++ b/src/server.js
@@ -101,6 +101,7 @@ const plugin: RPCPluginType =
       const parseBody = bodyparser(bodyParserOptions);
 
       return async (ctx, next) => {
+        await next();
         const scopedEmitter = emitter.from(ctx);
         if (ctx.method === 'POST' && ctx.path.startsWith('/api/')) {
           const startTime = ms();
@@ -159,7 +160,6 @@ const plugin: RPCPluginType =
             }
           }
         }
-        return next();
       };
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,6 +3590,10 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
+mock-req@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/mock-req/-/mock-req-0.2.0.tgz#749446804d2c006169342ee7be6bba1cffd534c2"
+
 mri@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"


### PR DESCRIPTION
We should await next in the middleware to allow for other plugins to do authentication/authorization before rpc handlers are executed. 