### PR TITLE
Fix Flow complaints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
   "dependencies": {
-    "body-parser": "^1.18.2",
+    "body-parser": "^1.18.3",
     "koa-bodyparser": "4.2.0",
-    "rollup": "^0.58.2"
+    "rollup": "^0.59.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",
@@ -33,16 +33,16 @@
     "eslint-config-uber-universal-stage-3": "1.0.0-rc.7",
     "eslint-plugin-cup": "^1.0.2",
     "eslint-plugin-flowtype": "^2.46.3",
-    "eslint-plugin-import": "^2.11.0",
+    "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-prettier": "2.6.0",
-    "eslint-plugin-react": "7.7.0",
+    "eslint-plugin-react": "^7.8.2",
     "flow-bin": "^0.72.0",
-    "fusion-core": "^1.2.6",
+    "fusion-core": "^1.3.1-1",
     "fusion-plugin-universal-events": "^1.0.3",
-    "fusion-test-utils": "^1.0.5",
+    "fusion-test-utils": "^1.1.0",
     "fusion-tokens": "^1.0.3",
     "mock-req": "^0.2.0",
-    "nyc": "^11.7.2",
+    "nyc": "^11.8.0",
     "prettier": "^1.12.1",
     "tape-cup": "4.7.1",
     "unitest": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "2.6.0",
     "eslint-plugin-react": "^7.8.2",
     "flow-bin": "^0.72.0",
-    "fusion-core": "^1.3.1-1",
+    "fusion-core": "^1.3.0",
     "fusion-plugin-universal-events": "^1.0.3",
     "fusion-test-utils": "^1.1.0",
     "fusion-tokens": "^1.0.3",

--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -20,6 +20,7 @@ function createTestFixture() {
     Promise.resolve({json: () => ({status: 'success', data: args})});
 
   const app = new App('content', el => el);
+  // $FlowFixMe
   app.register(FetchToken, mockFetch);
   app.register(MockPluginToken, RPCPlugin);
   return app;
@@ -67,6 +68,7 @@ test('failure status request', t => {
     Promise.resolve({json: () => ({status: 'failure', data: 'failure data'})});
 
   const app = createTestFixture();
+  // $FlowFixMe
   app.register(FetchToken, mockFetchAsFailure);
 
   let wasResolved = false;

--- a/src/__tests__/test-mock.js
+++ b/src/__tests__/test-mock.js
@@ -10,7 +10,6 @@ import test from 'tape-cup';
 
 import App, {createPlugin, createToken} from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
-
 import {RPCHandlersToken} from '../tokens';
 import RPCPlugin from '../mock';
 

--- a/src/types.js
+++ b/src/types.js
@@ -24,7 +24,7 @@ export type RPCScopedServiceType = {
 };
 
 export type RPCServiceType = {
-  from: (ctx: Context) => RPCScopedServiceType,
+  from: (ctx?: Context) => RPCScopedServiceType,
 };
 
 export type RPCPluginType = FusionPlugin<*, RPCServiceType>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,9 +747,9 @@
   version "0.9.46"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
 
-"@types/estree@0.0.38":
-  version "0.0.38"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
 "@types/mkdirp@^0.3.29":
   version "0.3.29"
@@ -1159,20 +1159,20 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-body-parser@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
+body-parser@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   dependencies:
     bytes "3.0.0"
     content-type "~1.0.4"
     debug "2.6.9"
-    depd "~1.1.1"
-    http-errors "~1.6.2"
-    iconv-lite "0.4.19"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
     on-finished "~2.3.0"
-    qs "6.5.1"
-    raw-body "2.3.2"
-    type-is "~1.6.15"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1773,10 +1773,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
 depd@^1.1.0, depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2035,9 +2031,9 @@ eslint-plugin-flowtype@^2.46.3:
   dependencies:
     lodash "^4.15.0"
 
-eslint-plugin-import@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz#15aeea37a67499d848e8e981806d4627b5503816"
+eslint-plugin-import@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
   dependencies:
     contains-path "^0.1.0"
     debug "^2.6.8"
@@ -2057,9 +2053,9 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-eslint-plugin-react@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+eslint-plugin-react@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:
     doctrine "^2.0.2"
     has "^1.0.1"
@@ -2430,14 +2426,14 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.2.6.tgz#f9d0059db928d4ba73fe847f2d7d014f44a85dca"
+fusion-core@^1.3.1-1:
+  version "1.3.1-1"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.3.1-1.tgz#9411282d3afa65c11d888adb384b33eaceeb0ac1"
   dependencies:
     koa "^2.4.1"
     koa-compose "^4.0.0"
     node-mocks-http "^1.6.6"
-    toposort "^1.0.6"
+    toposort "^2.0.1"
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
 
@@ -2447,9 +2443,9 @@ fusion-plugin-universal-events@^1.0.3:
   dependencies:
     koa-bodyparser "4.2.0"
 
-fusion-test-utils@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.0.5.tgz#6ac2d2af57e7201b4c6e3e13ac2524d423e8e4c7"
+fusion-test-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.1.0.tgz#1900a7d432733f935698ee139cef3a1e8f6ab973"
   dependencies:
     assert "^1.4.1"
     koa "^2.4.1"
@@ -2682,16 +2678,7 @@ http-assert@^1.1.0:
     deep-equal "~1.0.1"
     http-errors "~1.6.1"
 
-http-errors@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
-  dependencies:
-    depd "1.1.1"
-    inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
-
-http-errors@1.6.3, http-errors@^1.2.8, http-errors@~1.6.1, http-errors@~1.6.2:
+http-errors@1.6.3, http-errors@^1.2.8, http-errors@~1.6.1, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
@@ -2703,10 +2690,6 @@ http-errors@1.6.3, http-errors@^1.2.8, http-errors@~1.6.1, http-errors@~1.6.2:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
-
-iconv-lite@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
@@ -3745,9 +3728,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^11.7.2:
-  version "11.7.2"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.7.2.tgz#15e554f937c216cc91aa08f9a260256ed6fe44b8"
+nyc@^11.8.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.8.0.tgz#1e8453b0644f8fea4d829b1a6636663157cd3b00"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -4102,11 +4085,7 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-qs@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-qs@^6.4.0:
+qs@6.5.2, qs@^6.4.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -4143,16 +4122,7 @@ range-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
-  dependencies:
-    bytes "3.0.0"
-    http-errors "1.6.2"
-    iconv-lite "0.4.19"
-    unpipe "1.0.0"
-
-raw-body@^2.2.0:
+raw-body@2.3.3, raw-body@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
   dependencies:
@@ -4398,11 +4368,11 @@ rollup@^0.55.1:
   version "0.55.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.5.tgz#2f88c300f7cf24b5ec2dca8a6aba73b04e087e93"
 
-rollup@^0.58.2:
-  version "0.58.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.58.2.tgz#2feddea8c0c022f3e74b35c48e3c21b3433803ce"
+rollup@^0.59.1:
+  version "0.59.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.59.1.tgz#86cbceaecd861df1317a0aa29207173de23e6a5d"
   dependencies:
-    "@types/estree" "0.0.38"
+    "@types/estree" "0.0.39"
     "@types/node" "*"
 
 run-async@^2.2.0:
@@ -4482,10 +4452,6 @@ set-value@^2.0.0:
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -4637,7 +4603,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2", statuses@^1.2.0:
+"statuses@>= 1.4.0 < 2", statuses@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
@@ -4877,9 +4843,9 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toposort@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
+toposort@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
 
 tosource@^1.0.0:
   version "1.0.0"
@@ -4899,7 +4865,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@^1.5.5, type-is@^1.6.14, type-is@~1.6.15:
+type-is@^1.5.5, type-is@^1.6.14, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,9 +2426,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-core@^1.3.1-1:
-  version "1.3.1-1"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.3.1-1.tgz#9411282d3afa65c11d888adb384b33eaceeb0ac1"
+fusion-core@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.3.0.tgz#9b2db6f686baec6fe4b01c92dda72817630a3fea"
   dependencies:
     koa "^2.4.1"
     koa-compose "^4.0.0"


### PR DESCRIPTION
Fixes the following complaints:

```
$ /Users/amsmith/Code/GitHub/fusion-plugin-rpc/node_modules/.bin/flow
Launching Flow server for /Users/amsmith/Code/GitHub/fusion-plugin-rpc
Spawned flow server (pid=55482)
Logs will go to /private/tmp/flow/zSUserszSamsmithzSCodezSGitHubzSfusion-plugin-rpc.log
Monitor logs will go to /private/tmp/flow/zSUserszSamsmithzSCodezSGitHubzSfusion-plugin-rpc.monitor_log
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.browser.js:23:28

Cannot call app.register with mockFetch bound to val because object literal [1] is incompatible with Response [2] in
type argument R [3] of the return value.

     src/__tests__/index.browser.js
 [1]  20│     Promise.resolve({json: () => ({status: 'success', data: args})});
      21│
      22│   const app = new App('content', el => el);
      23│   app.register(FetchToken, mockFetch);
      24│   app.register(MockPluginToken, RPCPlugin);
      25│   return app;
      26│ }

     /private/tmp/flow/flowlib_1f146703/core.js
 [3] 576│ declare class Promise<+R> {

     node_modules/fusion-tokens/src/index.js
 [2]  10│ ) => Promise<Response>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.browser.js:24:33

Cannot call app.register because property from is missing in FusionPlugin [1] but exists in RPCServiceType [2].

     src/__tests__/index.browser.js
     21│
     22│   const app = new App('content', el => el);
     23│   app.register(FetchToken, mockFetch);
     24│   app.register(MockPluginToken, RPCPlugin);
     25│   return app;
     26│ }
     27│

     src/browser.js
 [1] 64│ export default ((__BROWSER__ && plugin: any): RPCPluginType);

     src/types.js
 [2] 30│ export type RPCPluginType = FusionPlugin<*, RPCServiceType>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.browser.js:70:28

Cannot call app.register with mockFetchAsFailure bound to val because object literal [1] is incompatible with
Response [2] in type argument R [3] of the return value.

     src/__tests__/index.browser.js
 [1]  67│     Promise.resolve({json: () => ({status: 'failure', data: 'failure data'})});
      68│
      69│   const app = createTestFixture();
      70│   app.register(FetchToken, mockFetchAsFailure);
      71│
      72│   let wasResolved = false;
      73│   getSimulator(

     /private/tmp/flow/flowlib_1f146703/core.js
 [3] 576│ declare class Promise<+R> {

     node_modules/fusion-tokens/src/index.js
 [2]  10│ ) => Promise<Response>;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.node.js:26:51

Cannot call MockRPCPlugin.provides because undefined [1] is not a function.

     src/__tests__/index.node.js
     23│ const MockPluginToken: Token<RPCServiceType> = createToken('test-plugin-token');
     24│ const MOCK_JSON_PARAMS = {test: 'test-args'};
     25│
     26│ const mockService: RPCServiceType = MockRPCPlugin.provides({});
     27│
     28│ function createTestFixture() {
     29│   const mockHandlers = {};

     node_modules/fusion-core/src/types.js
 [1] 40│   provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.node.js:121:32

Cannot call RPCPlugin.provides because undefined [1] is not a function.

     src/__tests__/index.node.js
     118│     },
     119│   };
     120│
     121│   const rpcFactory = RPCPlugin.provides({
     122│     emitter: mockEmitter,
     123│     handlers: mockHandlers,
     124│   });
     125│   const rpc = rpcFactory.from(mockCtx);
     126│
     127│   t.equals(typeof rpc.request, 'function', 'has request method');

     node_modules/fusion-core/src/types.js
 [1]  40│   provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.node.js:162:32

Cannot call RPCPlugin.provides because undefined [1] is not a function.

     src/__tests__/index.node.js
     159│     },
     160│   };
     161│
     162│   const rpcFactory = RPCPlugin.provides({
     163│     emitter: mockEmitter,
     164│     handlers: mockHandlers,
     165│   });
     166│   const rpc = rpcFactory.from(mockCtx);
     167│
     168│   t.equals(typeof rpc.request, 'function', 'has request method');

     node_modules/fusion-core/src/types.js
 [1]  40│   provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/index.node.js:198:32

Cannot call RPCPlugin.provides because undefined [1] is not a function.

     src/__tests__/index.node.js
     195│     },
     196│   };
     197│
     198│   const rpcFactory = RPCPlugin.provides({
     199│     emitter: mockEmitter,
     200│     handlers: mockHandlers,
     201│   });
     202│   const rpc = rpcFactory.from(mockCtx);
     203│
     204│   t.equals(typeof rpc.request, 'function', 'has request method');

     node_modules/fusion-core/src/types.js
 [1]  40│   provides?: (Deps: $ObjMap<Deps & {}, ExtractReturnType>) => Service,


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/__tests__/test-mock.js:23:33

Cannot call app.register because property from is missing in FusionPlugin [1] but exists in RPCServiceType [2].

     src/__tests__/test-mock.js
     20│
     21│   const app = new App('content', el => el);
     22│   app.register(RPCHandlersToken, mockHandlers);
     23│   app.register(MockPluginToken, RPCPlugin);
     24│   return app;
     25│ }
     26│

     src/mock.js
 [1] 39│ const plugin: RPCPluginType = createPlugin({

     src/types.js
 [2] 30│ export type RPCPluginType = FusionPlugin<*, RPCServiceType>;



Found 8 errors

Only showing the most relevant union/intersection branches.
To see all branches, re-run Flow with --show-all-branches
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```