### PR TITLE
Allow adding headers to browser initiated RPC calls

### DIFF
--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -76,7 +76,7 @@ test('success status request w/args and header', t => {
         t.equals(typeof rpc.request, 'function', 'has method');
         t.ok(rpc.request('test') instanceof Promise, 'has right return type');
         rpc
-          .request('test', { args: 1 }, { 'test-header': 'header value' })
+          .request('test', {args: 1}, {'test-header': 'header value'})
           .then(([url, options]) => {
             t.equals(url, '/api/test', 'has right url');
             t.equals(options.method, 'POST', 'has right http method');
@@ -104,8 +104,6 @@ test('success status request w/args and header', t => {
   t.true(wasResolved, 'plugin was resolved');
   t.end();
 });
-
-
 
 test('failure status request', t => {
   const mockFetchAsFailure = () =>

--- a/src/__tests__/index.browser.js
+++ b/src/__tests__/index.browser.js
@@ -6,110 +6,110 @@
  * @flow
  */
 
-import test from "tape-cup";
+import test from 'tape-cup';
 
-import App, { createPlugin, createToken } from "fusion-core";
-import { FetchToken } from "fusion-tokens";
-import { getSimulator } from "fusion-test-utils";
+import App, {createPlugin, createToken} from 'fusion-core';
+import {FetchToken} from 'fusion-tokens';
+import {getSimulator} from 'fusion-test-utils';
 
-import RPCPlugin from "../browser";
+import RPCPlugin from '../browser';
 
-const MockPluginToken = createToken("test-plugin-token");
+const MockPluginToken = createToken('test-plugin-token');
 function createTestFixture() {
   const mockFetch = (...args) =>
-    Promise.resolve({ json: () => ({ status: "success", data: args }) });
+    Promise.resolve({json: () => ({status: 'success', data: args})});
 
-  const app = new App("content", el => el);
+  const app = new App('content', el => el);
   // $FlowFixMe
   app.register(FetchToken, mockFetch);
   app.register(MockPluginToken, RPCPlugin);
   return app;
 }
 
-test("success status request", t => {
+test('success status request', t => {
   const app = createTestFixture();
 
   let wasResolved = false;
   getSimulator(
     app,
     createPlugin({
-      deps: { rpcFactory: MockPluginToken },
+      deps: {rpcFactory: MockPluginToken},
       provides: deps => {
         const rpc = deps.rpcFactory.from();
-        t.equals(typeof rpc.request, "function", "has method");
-        t.ok(rpc.request("test") instanceof Promise, "has right return type");
+        t.equals(typeof rpc.request, 'function', 'has method');
+        t.ok(rpc.request('test') instanceof Promise, 'has right return type');
         rpc
-          .request("test")
+          .request('test')
           .then(([url, options]) => {
-            t.equals(url, "/api/test", "has right url");
-            t.equals(options.method, "POST", "has right http method");
+            t.equals(url, '/api/test', 'has right url');
+            t.equals(options.method, 'POST', 'has right http method');
             t.equals(
-              options.headers["Content-Type"],
-              "application/json",
-              "has right content-type"
+              options.headers['Content-Type'],
+              'application/json',
+              'has right content-type'
             );
-            t.equals(options.body, "{}", "has right body");
+            t.equals(options.body, '{}', 'has right body');
           })
           .catch(e => {
             t.fail(e);
           });
 
         wasResolved = true;
-      }
+      },
     })
   );
 
-  t.true(wasResolved, "plugin was resolved");
+  t.true(wasResolved, 'plugin was resolved');
   t.end();
 });
 
-test("success status request w/args and header", t => {
+test('success status request w/args and header', t => {
   const app = createTestFixture();
 
   let wasResolved = false;
   getSimulator(
     app,
     createPlugin({
-      deps: { rpcFactory: MockPluginToken },
+      deps: {rpcFactory: MockPluginToken},
       provides: deps => {
         const rpc = deps.rpcFactory.from();
-        t.equals(typeof rpc.request, "function", "has method");
-        t.ok(rpc.request("test") instanceof Promise, "has right return type");
+        t.equals(typeof rpc.request, 'function', 'has method');
+        t.ok(rpc.request('test') instanceof Promise, 'has right return type');
         rpc
-          .request("test", { args: 1 }, { "test-header": "header value" })
+          .request('test', { args: 1 }, { 'test-header': 'header value' })
           .then(([url, options]) => {
-            t.equals(url, "/api/test", "has right url");
-            t.equals(options.method, "POST", "has right http method");
+            t.equals(url, '/api/test', 'has right url');
+            t.equals(options.method, 'POST', 'has right http method');
             t.equals(
-              options.headers["Content-Type"],
-              "application/json",
-              "has right content-type"
+              options.headers['Content-Type'],
+              'application/json',
+              'has right content-type'
             );
             t.equals(
-              options.headers["test-header"],
-              "header value",
-              "header is passed"
+              options.headers['test-header'],
+              'header value',
+              'header is passed'
             );
-            t.equals(options.body, '{"args":1}', "has right body");
+            t.equals(options.body, '{"args":1}', 'has right body');
           })
           .catch(e => {
             t.fail(e);
           });
 
         wasResolved = true;
-      }
+      },
     })
   );
 
-  t.true(wasResolved, "plugin was resolved");
+  t.true(wasResolved, 'plugin was resolved');
   t.end();
 });
 
-test("failure status request", t => {
+
+
+test('failure status request', t => {
   const mockFetchAsFailure = () =>
-    Promise.resolve({
-      json: () => ({ status: "failure", data: "failure data" })
-    });
+    Promise.resolve({json: () => ({status: 'failure', data: 'failure data'})});
 
   const app = createTestFixture();
   // $FlowFixMe
@@ -119,26 +119,26 @@ test("failure status request", t => {
   getSimulator(
     app,
     createPlugin({
-      deps: { rpcFactory: MockPluginToken },
+      deps: {rpcFactory: MockPluginToken},
       provides: deps => {
         const rpc = deps.rpcFactory.from();
-        t.equals(typeof rpc.request, "function", "has method");
-        const testRequest = rpc.request("test");
-        t.ok(testRequest instanceof Promise, "has right return type");
+        t.equals(typeof rpc.request, 'function', 'has method');
+        const testRequest = rpc.request('test');
+        t.ok(testRequest instanceof Promise, 'has right return type');
         testRequest
           .then(() => {
             // $FlowFixMe
-            t.fail(() => new Error("should reject promise"));
+            t.fail(() => new Error('should reject promise'));
           })
           .catch(e => {
-            t.equal(e, "failure data", "should pass failure data through");
+            t.equal(e, 'failure data', 'should pass failure data through');
           });
 
         wasResolved = true;
-      }
+      },
     })
   );
 
-  t.true(wasResolved, "plugin was resolved");
+  t.true(wasResolved, 'plugin was resolved');
   t.end();
 });

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,11 +8,11 @@
 
 /* eslint-env browser */
 
-import { createPlugin } from "fusion-core";
-import { FetchToken } from "fusion-tokens";
-import type { Fetch } from "fusion-tokens";
+import {createPlugin} from 'fusion-core';
+import {FetchToken} from 'fusion-tokens';
+import type {Fetch} from 'fusion-tokens';
 
-import type { RPCPluginType } from "./types.js";
+import type {RPCPluginType} from './types.js';
 
 class RPC {
   ctx: ?*;
@@ -26,23 +26,23 @@ class RPC {
 
   request(rpcId: string, args: *, headers: ?{[string]: string}): Promise<*> {
     if (!this.fetch) {
-      throw new Error("fusion-plugin-rpc requires `fetch`");
+      throw new Error('fusion-plugin-rpc requires `fetch`');
     }
     const fetch = this.fetch;
 
     // TODO(#3) handle args instanceof FormData
     return fetch(`/api/${rpcId}`, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
-        ...(headers || {})
+        'Content-Type': 'application/json',
+        ...(headers || {}),
       },
-      body: JSON.stringify(args || {})
+      body: JSON.stringify(args || {}),
     })
       .then(r => r.json())
       .then(args => {
-        const { status, data } = args;
-        if (status === "success") {
+        const {status, data} = args;
+        if (status === 'success') {
           return data;
         } else {
           return Promise.reject(data);
@@ -53,13 +53,13 @@ class RPC {
 
 const plugin: RPCPluginType = createPlugin({
   deps: {
-    fetch: FetchToken
+    fetch: FetchToken,
   },
   provides: deps => {
-    const { fetch = window.fetch } = deps;
+    const {fetch = window.fetch} = deps;
 
-    return { from: () => new RPC(fetch) };
-  }
+    return {from: () => new RPC(fetch)};
+  },
 });
 
 export default ((__BROWSER__ && plugin: any): RPCPluginType);

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,11 +8,11 @@
 
 /* eslint-env browser */
 
-import {createPlugin} from 'fusion-core';
-import {FetchToken} from 'fusion-tokens';
-import type {Fetch} from 'fusion-tokens';
+import { createPlugin } from "fusion-core";
+import { FetchToken } from "fusion-tokens";
+import type { Fetch } from "fusion-tokens";
 
-import type {RPCPluginType} from './types.js';
+import type { RPCPluginType } from "./types.js";
 
 class RPC {
   ctx: ?*;
@@ -24,25 +24,25 @@ class RPC {
     this.fetch = fetch;
   }
 
-  request(rpcId: string, args: *, headers: *): Promise<*> {
+  request(rpcId: string, args: *, headers: ?{[string]: string}): Promise<*> {
     if (!this.fetch) {
-      throw new Error('fusion-plugin-rpc requires `fetch`');
+      throw new Error("fusion-plugin-rpc requires `fetch`");
     }
     const fetch = this.fetch;
 
     // TODO(#3) handle args instanceof FormData
     return fetch(`/api/${rpcId}`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         ...(headers || {})
       },
-      body: JSON.stringify(args || {}),
+      body: JSON.stringify(args || {})
     })
       .then(r => r.json())
       .then(args => {
-        const {status, data} = args;
-        if (status === 'success') {
+        const { status, data } = args;
+        if (status === "success") {
           return data;
         } else {
           return Promise.reject(data);
@@ -53,13 +53,13 @@ class RPC {
 
 const plugin: RPCPluginType = createPlugin({
   deps: {
-    fetch: FetchToken,
+    fetch: FetchToken
   },
   provides: deps => {
-    const {fetch = window.fetch} = deps;
+    const { fetch = window.fetch } = deps;
 
-    return {from: () => new RPC(fetch)};
-  },
+    return { from: () => new RPC(fetch) };
+  }
 });
 
 export default ((__BROWSER__ && plugin: any): RPCPluginType);

--- a/src/browser.js
+++ b/src/browser.js
@@ -24,7 +24,7 @@ class RPC {
     this.fetch = fetch;
   }
 
-  request(rpcId: string, args: *): Promise<*> {
+  request(rpcId: string, args: *, headers: *): Promise<*> {
     if (!this.fetch) {
       throw new Error('fusion-plugin-rpc requires `fetch`');
     }
@@ -35,6 +35,7 @@ class RPC {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(headers || {})
       },
       body: JSON.stringify(args || {}),
     })


### PR DESCRIPTION
There is currently no way to add headers to a RPC call made from the browser. This PR adds that functionality while not breaking any existing use cases. 