### PR TITLE
Release v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-rpc",
   "description": "Fetch data on the server and client with an RPC style interface.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": "fusionjs/fusion-plugin-rpc",
   "files": [
     "dist",


### PR DESCRIPTION
- Standardize dependency heading sizes ([#168](https://github.com/fusionjs/fusion-plugin-rpc/pull/168))
- Fix token type to fix release verification ([#162](https://github.com/fusionjs/fusion-plugin-rpc/pull/162))
- Fix typo in code example ([#165](https://github.com/fusionjs/fusion-plugin-rpc/pull/165))
- Update uber/web-base-image Docker tag to v1.0.7 ([#159](https://github.com/fusionjs/fusion-plugin-rpc/pull/159))