### PR TITLE
Fix treeshaking for plugin exports

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -47,7 +47,7 @@ function createTestFixture() {
   return app;
 }
 
-function createMockEmitter(props: mixed): IEmitter {
+function createMockEmitter<TProps>(props: TProps): IEmitter {
   const emitter = {
     from: () => {
       return emitter;
@@ -60,7 +60,7 @@ function createMockEmitter(props: mixed): IEmitter {
     off: () => {},
     mapEvent: () => {},
     handleEvent: () => {},
-    flush: () => {},
+    flush: () => undefined,
     ...props,
   };
   return emitter;
@@ -288,7 +288,7 @@ test('middleware - invalid endpoint', async t => {
     something: () => {},
     other: () => {},
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:error');
       t.equal(payload.method, 'valueOf');
@@ -299,10 +299,7 @@ test('middleware - invalid endpoint', async t => {
         'emits error in payload'
       );
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&
@@ -354,7 +351,7 @@ test('middleware - valid endpoint', async t => {
       return 1;
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -362,10 +359,7 @@ test('middleware - valid endpoint', async t => {
       t.equal(payload.status, 'success');
       t.equal(typeof payload.timing, 'number');
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&
@@ -416,7 +410,7 @@ test('middleware - valid endpoint with route prefix', async t => {
       return 1;
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -424,10 +418,7 @@ test('middleware - valid endpoint with route prefix', async t => {
       t.equal(payload.status, 'success');
       t.equal(typeof payload.timing, 'number');
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&
@@ -478,7 +469,7 @@ test('middleware - valid endpoint failure with ResponseError', async t => {
       return Promise.reject(e);
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -487,10 +478,7 @@ test('middleware - valid endpoint failure with ResponseError', async t => {
       t.equal(typeof payload.timing, 'number');
       t.equal(payload.error, e);
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&
@@ -549,7 +537,7 @@ test('middleware - valid endpoint failure with standard error', async t => {
       return Promise.reject(e);
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -558,10 +546,7 @@ test('middleware - valid endpoint failure with standard error', async t => {
       t.equal(typeof payload.timing, 'number');
       t.notEqual(payload.error, e);
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&
@@ -637,7 +622,7 @@ test('middleware - bodyparser options with very small jsonLimit', async t => {
       return 1;
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -645,10 +630,7 @@ test('middleware - bodyparser options with very small jsonLimit', async t => {
       t.equal(payload.status, 'success');
       t.equal(typeof payload.timing, 'number');
     },
-    from() {
-      return this;
-    },
-  };
+  });
   const mockBodyParserOptions = {jsonLimit: '1b'};
 
   const middleware =
@@ -694,7 +676,7 @@ test('middleware - bodyparser options with default jsonLimit', async t => {
       return 1;
     },
   };
-  const mockEmitter = {
+  const mockEmitter = createMockEmitter({
     emit(type, payload) {
       t.equal(type, 'rpc:method');
       t.equal(payload.method, 'test');
@@ -702,10 +684,7 @@ test('middleware - bodyparser options with default jsonLimit', async t => {
       t.equal(payload.status, 'success');
       t.equal(typeof payload.timing, 'number');
     },
-    from() {
-      return this;
-    },
-  };
+  });
 
   const middleware =
     RPCPlugin.middleware &&

--- a/src/__tests__/test-mock.js
+++ b/src/__tests__/test-mock.js
@@ -8,12 +8,20 @@
 
 import test from 'tape-cup';
 
-import App, {createPlugin, createToken} from 'fusion-core';
+import App, {
+  createPlugin,
+  createToken,
+  type Token,
+  type Context,
+} from 'fusion-core';
 import {getSimulator} from 'fusion-test-utils';
+
 import {RPCHandlersToken} from '../tokens';
 import RPCPlugin from '../mock';
+import type {RPCServiceType} from '../types.js';
 
-const MockPluginToken = createToken('test-plugin-token');
+const MockPluginToken: Token<RPCServiceType> = createToken('test-plugin-token');
+const mockCtx = (({}: any): Context);
 function createTestFixture() {
   const mockHandlers = {};
 
@@ -32,7 +40,7 @@ test('mock with missing handler', async t => {
     createPlugin({
       deps: {rpcFactory: MockPluginToken},
       provides: async deps => {
-        const rpc = deps.rpcFactory.from();
+        const rpc = deps.rpcFactory.from(mockCtx);
         try {
           await rpc.request('test');
         } catch (e) {
@@ -62,7 +70,7 @@ test('mock with handler', async t => {
     createPlugin({
       deps: {rpcFactory: MockPluginToken},
       provides: async deps => {
-        const rpc = deps.rpcFactory.from();
+        const rpc = deps.rpcFactory.from(mockCtx);
 
         try {
           const result = await rpc.request('test', {test: 'args'});

--- a/src/browser.js
+++ b/src/browser.js
@@ -51,15 +51,16 @@ class RPC {
   }
 }
 
-const plugin: RPCPluginType = createPlugin({
-  deps: {
-    fetch: FetchToken,
-  },
-  provides: deps => {
-    const {fetch = window.fetch} = deps;
+const pluginFactory: () => RPCPluginType = () =>
+  createPlugin({
+    deps: {
+      fetch: FetchToken,
+    },
+    provides: deps => {
+      const {fetch = window.fetch} = deps;
 
-    return {from: () => new RPC(fetch)};
-  },
-});
+      return {from: () => new RPC(fetch)};
+    },
+  });
 
-export default ((__BROWSER__ && plugin: any): RPCPluginType);
+export default ((__BROWSER__ && pluginFactory(): any): RPCPluginType);

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,23 +8,28 @@
 
 /* eslint-env browser */
 
-import {createPlugin} from 'fusion-core';
+import {createPlugin, type Context} from 'fusion-core';
 import {FetchToken} from 'fusion-tokens';
 import type {Fetch} from 'fusion-tokens';
 
-import type {RPCPluginType} from './types.js';
+import type {HandlerType} from './tokens.js';
+import type {RPCPluginType, IEmitter} from './types.js';
 
 class RPC {
-  ctx: ?*;
-  emitter: ?*;
-  handlers: ?*;
+  ctx: ?Context;
+  emitter: ?IEmitter;
+  handlers: ?HandlerType;
   fetch: ?Fetch;
 
   constructor(fetch: Fetch) {
     this.fetch = fetch;
   }
 
-  request(rpcId: string, args: *, headers: ?{[string]: string}): Promise<*> {
+  request<TArgs, TResult>(
+    rpcId: string,
+    args: TArgs,
+    headers: ?{[string]: string}
+  ): Promise<TResult> {
     if (!this.fetch) {
       throw new Error('fusion-plugin-rpc requires `fetch`');
     }

--- a/src/mock.js
+++ b/src/mock.js
@@ -8,6 +8,7 @@
 
 import {createPlugin} from 'fusion-core';
 import type {Context} from 'fusion-core';
+import type {Fetch} from 'fusion-tokens';
 
 import MissingHandlerError from './missing-handler-error';
 import {RPCHandlersToken} from './tokens';
@@ -18,13 +19,13 @@ class RPC {
   ctx: ?Context;
   emitter: ?IEmitter;
   handlers: ?HandlerType;
-  fetch: ?*;
+  fetch: ?Fetch;
 
   constructor(handlers: any) {
     this.handlers = handlers;
   }
 
-  async request(method: string, args: mixed) {
+  async request<TArgs, TResult>(method: string, args: TArgs): Promise<TResult> {
     if (!this.handlers) {
       throw new Error('fusion-plugin-rpc requires `handlers`');
     }

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import bodyparser from 'koa-bodyparser';
 import {createPlugin, memoize} from 'fusion-core';
 import type {Context} from 'fusion-core';
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
+import type {Fetch} from 'fusion-tokens';
 
 import MissingHandlerError from './missing-handler-error';
 import ResponseError from './response-error';
@@ -31,7 +32,7 @@ class RPC {
   ctx: ?Context;
   emitter: ?IEmitter;
   handlers: ?HandlerType;
-  fetch: ?*;
+  fetch: ?Fetch;
 
   constructor(emitter: any, handlers: any, ctx: Context): RPC {
     if (!ctx || !ctx.headers) {
@@ -44,7 +45,7 @@ class RPC {
     return this;
   }
 
-  async request(method: string, args: mixed) {
+  async request<TArgs, TResult>(method: string, args: TArgs): Promise<TResult> {
     const startTime = ms();
 
     if (!this.ctx) {
@@ -115,7 +116,7 @@ const pluginFactory: () => RPCPluginType = () =>
     middleware: deps => {
       const {emitter, handlers, bodyParserOptions} = deps;
       if (!handlers)
-        throw new Error('Middle handlers registered to RPCHandlersToken');
+        throw new Error('Missing handlers registered to RPCHandlersToken');
       if (!emitter)
         throw new Error('Missing emitter registered to UniversalEventsToken');
       const parseBody = bodyparser(bodyParserOptions);
@@ -198,4 +199,4 @@ function ms() {
   return Math.round(seconds * 1000 + ns / 1e6);
 }
 
-export default ((__NODE__ && pluginFactory: any): RPCPluginType);
+export default ((__NODE__ && pluginFactory(): any): RPCPluginType);

--- a/src/server.js
+++ b/src/server.js
@@ -95,8 +95,7 @@ class RPC {
   }
 }
 
-const plugin =
-  __NODE__ &&
+const pluginFactory: () => RPCPluginType = () =>
   createPlugin({
     deps: {
       emitter: UniversalEventsToken,
@@ -115,6 +114,10 @@ const plugin =
 
     middleware: deps => {
       const {emitter, handlers, bodyParserOptions} = deps;
+      if (!handlers)
+        throw new Error('Middle handlers registered to RPCHandlersToken');
+      if (!emitter)
+        throw new Error('Missing emitter registered to UniversalEventsToken');
       const parseBody = bodyparser(bodyParserOptions);
 
       return async (ctx, next) => {
@@ -195,4 +198,4 @@ function ms() {
   return Math.round(seconds * 1000 + ns / 1e6);
 }
 
-export default ((plugin: any): RPCPluginType);
+export default ((__NODE__ && pluginFactory: any): RPCPluginType);

--- a/src/types.js
+++ b/src/types.js
@@ -31,7 +31,7 @@ export type RPCScopedServiceType = {
   handlers: ?HandlerType,
   fetch: ?Fetch,
 
-  request(method: string, args: mixed): Promise<*>,
+  request<TArgs, TResult>(method: string, args: TArgs): Promise<TResult>,
 };
 
 export type RPCServiceType = {

--- a/src/types.js
+++ b/src/types.js
@@ -8,11 +8,22 @@
 
 import type {FusionPlugin, Context} from 'fusion-core';
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
-import type {Fetch} from 'fusion-tokens';
+import {type Fetch, FetchToken} from 'fusion-tokens';
 
-import type {HandlerType} from './tokens.js';
+import {
+  RPCHandlersToken,
+  BodyParserOptionsToken,
+  type HandlerType,
+} from './tokens.js';
 
 type ExtractReturnType = <V>(() => V) => V;
+
+export type RPCDepsType = {
+  emitter?: typeof UniversalEventsToken,
+  handlers?: typeof RPCHandlersToken,
+  bodyParserOptions?: typeof BodyParserOptionsToken.optional,
+  fetch?: typeof FetchToken,
+};
 
 export type RPCScopedServiceType = {
   ctx: ?Context,
@@ -24,9 +35,9 @@ export type RPCScopedServiceType = {
 };
 
 export type RPCServiceType = {
-  from: (ctx?: Context) => RPCScopedServiceType,
+  from: (ctx: Context) => RPCScopedServiceType,
 };
 
-export type RPCPluginType = FusionPlugin<*, RPCServiceType>;
+export type RPCPluginType = FusionPlugin<RPCDepsType, RPCServiceType>;
 
 export type IEmitter = $Call<ExtractReturnType, typeof UniversalEventsToken>;


### PR DESCRIPTION
Fixes [WPT-1422](https://jeng.uberinternal.com/browse/WPT-1422):

>Recent changes to fusion-plugin-i18n and fusion-plugin-rpc caused non-target implementations for plugins to bleed into bundles due to not being tree shaken out.

Thanks to @rtsao and @KevinGrandon for tracking down this issue!