### PR TITLE
Add full error details to RPC error event even if ResponseError is not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .DS_Store
 npm-debug.log
 yarn-error.log
+.idea/

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -544,7 +544,7 @@ test('middleware - valid endpoint failure with standard error', async t => {
       t.equal(payload.origin, 'browser');
       t.equal(payload.status, 'failure');
       t.equal(typeof payload.timing, 'number');
-      t.notEqual(payload.error, e);
+      t.equal(payload.error, e);
     },
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -163,7 +163,7 @@ const pluginFactory: () => RPCPluginType = () =>
               if (scopedEmitter) {
                 scopedEmitter.emit(statKey, {
                   method,
-                  error,
+                  error: e,
                   status: 'failure',
                   origin: 'browser',
                   timing: ms() - startTime,


### PR DESCRIPTION
- When we send messages to the client we shouldn't leak any information about the source code of the server
- When a user is debugging locally its helpful for a developer to see the full details of the error message

@cdlewis @ganemone 