### PR TITLE
Release v2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-rpc",
   "description": "Fetch data on the server and client with an RPC style interface.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "repository": "fusionjs/fusion-plugin-rpc",
   "files": [
     "dist",


### PR DESCRIPTION
- Add full error details to RPC error event even if ResponseError is not used ([#177](https://github.com/fusionjs/fusion-plugin-rpc/pull/177))