### PR TITLE
[flow] allow `ResponseError.code` to be a number

### DIFF
--- a/src/response-error.js
+++ b/src/response-error.js
@@ -7,7 +7,7 @@
  */
 
 export default class ResponseError extends Error {
-  code: ?string;
+  code: ?string | ?number;
   meta: ?Object;
 
   constructor(message: string) {


### PR DESCRIPTION
[try flow link](https://flow.org/try/#0KYDwDg9gTgLgBAE2AMwIYFcA28DGnUDOBcASsAZAHYHACiUU0coMwlCx9jUcA3gFBw4OCEgBccAPwEYUAJaUA5nAA+UyugC2AI2BQA3ILibgMVBMkB5bQCtgOGIaMjqs9A+gAKE0VSLgEjLySgCUfEZCBOhget7kBH7AIYZCQjAAFnIEAHQiSHAAvHAamJgpqRlZ2SZmhcVYZRFwXNC5qGAw6FDAAMpmOADWACpQqDjAnpUEADSk5FQ0LVDJRgC+-Ov8LjLMDHWUwADucxQQ1HQMXgDkVyv8elC5osB1AEwAzPpAA) to verify