### PR TITLE
Add getMockRpcHandlers util and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 npm-debug.log
 yarn-error.log
 .idea/
+.vscode

--- a/README.md
+++ b/README.md
@@ -254,15 +254,15 @@ For example:
 ```js
 import {getMockRpcHandlers, ResponseError} from 'fusion-plugin-rpc';
 
-const rpcFixtures = {
-  GET_USER_SUCCESS: {
+const rpcFixtures = [
+  {
     getUser: {
       firstName: 'John',
       lastName: 'Doe',
       uuid: 123,
     },
   },
-  UPDATE_USER: {
+  {
     updateUser: [{
       args: [{firstName: 'Jane'}],
       response: {
@@ -275,12 +275,9 @@ const rpcFixtures = {
       response: new ResponseError('Username cant be empty'),
     }]
   },
-};
+];
 
-const mockRpcHandlers = getMockRpcHandlers([
-  rpcFixtures.GET_USER_SUCCESS,
-  rpcFixtures.UPDATE_USER,
-]);
+const mockRpcHandlers = getMockRpcHandlers(rpcFixtures);
 
 const user = await mockRpcHandlers.getUser();
 

--- a/README.md
+++ b/README.md
@@ -195,17 +195,12 @@ const rpc: RPC = Rpc.from((ctx: Context));
 
 ### mock
 
-The package also exports a mock rpc plugin which can be useful for testing. For
-example:
-
-```js
-import {mock as MockRPC} from 'fusion-plugin-rpc';
-```
-
 The package also exports a mock RPC plugin which can be useful for testing. For
 example:
 
 ```js
+import {mock as MockRPC, RPCToken} from 'fusion-plugin-rpc';
+
 app.register(RPCToken, mock);
 ```
 
@@ -228,5 +223,71 @@ function testHandler() {
     };
     throw error;
   }
+}
+```
+
+### Generating mock RPC handlers from fixtures
+
+The package also exports a getMockRpcHandlers util which can be useful for testing.
+Fixtures need to be of the following type
+
+```js
+type RpcResponse = Object | ResponseError;
+type RpcResponseMap = Array<{
+  args: Array<*>,
+  response: RpcResponse,
+}>;
+type RpcFixtureT = {[string]: RpcResponseMap | RpcResponse};
+```
+
+`getMockRpcHandlers` has the following interface:
+
+```js
+type getMockRpcHandlersT = (
+  fixtures: Array<RpcFixtureT>,
+  onMockRpc?: OnMockRpcCallbackT
+) => HandlerType;
+```
+
+For example:
+
+```js
+import {getMockRpcHandlers, ResponseError} from 'fusion-plugin-rpc';
+
+const rpcFixtures = {
+  GET_USER_SUCCESS: {
+    getUser: {
+      firstName: 'John',
+      lastName: 'Doe',
+      uuid: 123,
+    },
+  },
+  UPDATE_USER: {
+    updateUser: [{
+      args: [{firstName: 'Jane'}],
+      response: {
+        firstName: 'John',
+        lastName: 'Doe',
+        uuid: 123,
+      },
+    }, {
+      args: [{firstName: ''}],
+      response: new ResponseError('Username cant be empty'),
+    }]
+  },
+};
+
+const mockRpcHandlers = getMockRpcHandlers([
+  rpcFixtures.GET_USER_SUCCESS,
+  rpcFixtures.UPDATE_USER,
+]);
+
+const user = await mockRpcHandlers.getUser();
+
+try {
+  const user = await mockRpcHandlers.updateUser({firstName: ''});
+} catch (updatedUserError) {
+  // When error object is passed as response in fixtures,
+  // it will be considered as a failure scenario and will be thrown by rpc handler.
 }
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "dependencies": {
     "body-parser": "^1.18.3",
+    "just-map-object": "^1.2.0",
     "koa-bodyparser": "4.2.1",
+    "lodash.isequal": "^4.5.0",
     "rollup": "^0.66.4"
   },
   "devDependencies": {
@@ -45,6 +47,7 @@
     "mock-req": "^0.2.0",
     "nyc": "^13.0.1",
     "prettier": "^1.14.3",
+    "sinon": "^7.1.1",
     "tape-cup": "4.7.1",
     "unitest": "2.1.1"
   },

--- a/src/__tests__/test-mock-rpc-handlers.browser.js
+++ b/src/__tests__/test-mock-rpc-handlers.browser.js
@@ -6,15 +6,15 @@ import ResponseError from '../response-error';
 
 test('mockRpcHandlers', async t => {
   t.plan(4);
-  const rpcFixtures = {
-    GET_USER_SUCCESS: {
+  const rpcFixtures = [
+    {
       getUser: {
         firstName: 'John',
         lastName: 'Doe',
         uuid: 123,
       },
     },
-    UPDATE_USER: {
+    {
       updateUser: [
         {
           args: [{firstName: 'Jane'}],
@@ -30,14 +30,11 @@ test('mockRpcHandlers', async t => {
         },
       ],
     },
-  };
+  ];
 
   const onMockRpcSpy = sinon.spy();
 
-  const mockRpcHandlers = getMockRpcHandlers(
-    [rpcFixtures.GET_USER_SUCCESS, rpcFixtures.UPDATE_USER],
-    onMockRpcSpy
-  );
+  const mockRpcHandlers = getMockRpcHandlers(rpcFixtures, onMockRpcSpy);
 
   const user = await mockRpcHandlers.getUser();
 

--- a/src/__tests__/test-mock-rpc-handlers.browser.js
+++ b/src/__tests__/test-mock-rpc-handlers.browser.js
@@ -1,0 +1,90 @@
+// @flow
+import test from 'tape-cup';
+import sinon from 'sinon';
+import getMockRpcHandlers from '../mock-rpc-handlers';
+import ResponseError from '../response-error';
+
+test('mockRpcHandlers', async t => {
+  t.plan(4);
+  const rpcFixtures = {
+    GET_USER_SUCCESS: {
+      getUser: {
+        firstName: 'John',
+        lastName: 'Doe',
+        uuid: 123,
+      },
+    },
+    UPDATE_USER: {
+      updateUser: [
+        {
+          args: [{firstName: 'Jane'}],
+          response: {
+            firstName: 'Jane',
+            lastName: 'Doe',
+            uuid: 123,
+          },
+        },
+        {
+          args: [{firstName: ''}],
+          response: new ResponseError('Username cant be empty'),
+        },
+      ],
+    },
+  };
+
+  const onMockRpcSpy = sinon.spy();
+
+  const mockRpcHandlers = getMockRpcHandlers(
+    [rpcFixtures.GET_USER_SUCCESS, rpcFixtures.UPDATE_USER],
+    onMockRpcSpy
+  );
+
+  const user = await mockRpcHandlers.getUser();
+
+  t.deepEqual(
+    user,
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+      uuid: 123,
+    },
+    'should return success response'
+  );
+
+  t.deepEqual(
+    onMockRpcSpy.getCall(0).args,
+    [
+      'getUser',
+      [],
+      {
+        firstName: 'John',
+        lastName: 'Doe',
+        uuid: 123,
+      },
+    ],
+    'should call getUser rpc handler, with correct args and returns correct response'
+  );
+
+  const updatedUser = await mockRpcHandlers.updateUser({firstName: 'Jane'});
+
+  t.deepEqual(
+    updatedUser,
+    {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      uuid: 123,
+    },
+    'should return error response '
+  );
+
+  try {
+    await mockRpcHandlers.updateUser({firstName: ''});
+  } catch (e) {
+    t.ok(
+      e instanceof Error && e.message === 'Username cant be empty',
+      'should return error response '
+    );
+  }
+
+  t.end();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -15,3 +15,5 @@ export {default as ResponseError} from './response-error';
 export default (__BROWSER__ ? browserDataFetching : serverDataFetching);
 
 export {BodyParserOptionsToken, RPCToken, RPCHandlersToken} from './tokens';
+
+export {default as getMockRpcHandlers} from './mock-rpc-handlers';

--- a/src/mock-rpc-handlers.js
+++ b/src/mock-rpc-handlers.js
@@ -1,0 +1,43 @@
+// @flow
+import mapObject from 'just-map-object';
+import isEqual from 'lodash.isequal';
+import ResponseError from './response-error';
+import {type HandlerType} from './tokens';
+
+type RpcResponse = Object | ResponseError;
+type RpcResponseMap = Array<{
+  args: Array<*>,
+  response: RpcResponse,
+}>;
+export type RpcFixtureT = {[string]: RpcResponseMap | RpcResponse};
+type OnMockRpcCallbackT = (
+  handler: string,
+  args: Array<*>,
+  response: RpcResponse
+) => void;
+
+const getMockRpcHandlers = (
+  fixtures: Array<RpcFixtureT>,
+  onMockRpc?: OnMockRpcCallbackT
+): HandlerType =>
+  fixtures.reduce(
+    (rpcHandlers, fixture) => ({
+      ...rpcHandlers,
+      ...mapObject(fixture, (rpcId, responseDetails) => async (...args) => {
+        const response = Array.isArray(responseDetails)
+          ? responseDetails.filter(item => isEqual(item.args, args))[0].response
+          : responseDetails;
+
+        onMockRpc && onMockRpc(rpcId, args, response);
+
+        if (response instanceof Error) {
+          throw response;
+        }
+
+        return response;
+      }),
+    }),
+    {}
+  );
+
+export default getMockRpcHandlers;

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,6 +767,28 @@
     invariant "^2.2.2"
     semver "^5.3.0"
 
+"@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
+
 "@types/core-js@^0.9.41":
   version "0.9.46"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.46.tgz#ea701ee34cbb6dfe6d100f1530319547c93c8d79"
@@ -929,6 +951,10 @@ arr-flatten@^1.0.1, arr-flatten@^1.1.0:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -1708,6 +1734,10 @@ destroy@^1.0.4:
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -2941,6 +2971,10 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -3063,6 +3097,14 @@ jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+
+just-map-object@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/just-map-object/-/just-map-object-1.2.0.tgz#2e523497bf95ac5c00ea620bb462446bdb721a81"
 
 keygrip@~1.0.2:
   version "1.0.3"
@@ -3231,9 +3273,25 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3548,6 +3606,16 @@ next-tick@1:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
+nise@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz#76cc3915925056ae6c405dd8ad5d12bde570c19f"
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-libs-browser@^2.0.0:
   version "2.1.0"
@@ -3938,6 +4006,12 @@ path-key@^2.0.0, path-key@^2.0.1:
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -4450,6 +4524,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sinon@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz#1202f317aa14d93cb9b69ff50b6bd49c0e05ffc9"
+  dependencies:
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^3.0.0"
+    nise "^1.4.6"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
@@ -4645,7 +4733,7 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
@@ -4728,6 +4816,10 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4807,6 +4899,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@^1.6.16, type-is@~1.6.16:
   version "1.6.16"


### PR DESCRIPTION
This PR includes `getMockRpcHandlers` util which helps to create mockRpcHandlers from fixtures

Fixtures need to be of the following type

```js
type RpcResponse = Object | ResponseError;
type RpcResponseMap = Array<{
  args: Array<*>,
  response: RpcResponse,
}>;
type RpcFixtureT = {[string]: RpcResponseMap | RpcResponse};
```

`getMockRpcHandlers` has the following interface:

```js
type getMockRpcHandlersT = (
  fixtures: Array<RpcFixtureT>,
  onMockRpc?: OnMockRpcCallbackT
) => HandlerType;
```