### PR TITLE
Release v2.3.1-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-rpc",
   "description": "Fetch data on the server and client with an RPC style interface.",
-  "version": "2.3.0",
+  "version": "2.3.1-0",
   "repository": "fusionjs/fusion-plugin-rpc",
   "files": [
     "dist",


### PR DESCRIPTION
- Migrate Flow to v0.91.0 and resolve errors ([#202](https://github.com/fusionjs/fusion-plugin-rpc/pull/202))